### PR TITLE
Correct asset paths and add catalog filter tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a lightweight, production-ready static website for **Gravexa Agrow** to 
 - Color system aligned to Gravexa palette: leafy green, deep blue, gold, sky blue, orange accents.
 
 ## Logo
-- Place your logo at `img/logo.png`. The current repo includes a copy of your provided logo.
+- Place your logo at `logo.png`. The current repo includes a copy of your provided logo.
 
 ## Deploy
 Any static host works:
@@ -22,7 +22,7 @@ Any static host works:
 
 ## Customize
 - Update contact info & addresses in `index.html` footer.
-- Add pricing or live inventory: extend `PRODUCTS` array in `js/app.js` with `price` values and optional fields.
+- Add pricing or live inventory: extend `PRODUCTS` array in `app.js` with `price` values and optional fields.
 - Add more images: replace generated SVG thumbs with product photos.
 
 ## Structured Data (optional)
@@ -61,4 +61,4 @@ docker run -p 8080:80 gravexa-agrow
 ### House-keeping
 - Format code: `npm run format`
 - Update `sitemap.xml` when adding pages.
-- Replace `img/logo.png` if you update the logo.
+- Replace `logo.png` if you update the logo.

--- a/app.js
+++ b/app.js
@@ -87,35 +87,13 @@ function setupInteractions(){
   const sort = document.getElementById('sort');
 
   function applyFilters(){
-    let list = PRODUCTS.slice();
-
-    const q = (search.value || '').toLowerCase().trim();
-    if(q) list = list.filter(p =>
-      p.name.toLowerCase().includes(q) ||
-      p.suta.toLowerCase().includes(q) ||
-      p.type.toLowerCase().includes(q) ||
-      p.notes.toLowerCase().includes(q)
-    );
-
-    if(category.value !== 'all'){
-      list = list.filter(p => p.type === category.value);
-    }
-
-    if(suta.value !== 'any'){
-      list = list.filter(p => p.suta.includes(suta.value));
-    }
-
-    if(pack.value !== 'any'){
-      list = list.filter(p => p.packs.includes(pack.value));
-    }
-
-    if(sort.value === 'name'){
-      list.sort((a,b) => a.name.localeCompare(b.name));
-    } else if (sort.value === 'suta'){
-      const n = s => parseInt(s.replace('+','').split('–')[0],10);
-      list.sort((a,b) => n(a.suta)-n(b.suta));
-    }
-
+    const list = filterProducts(PRODUCTS, {
+      search: search.value,
+      category: category.value,
+      suta: suta.value,
+      pack: pack.value,
+      sort: sort.value,
+    });
     render(list);
   }
 

--- a/filter.js
+++ b/filter.js
@@ -1,0 +1,42 @@
+function filterProducts(products, options = {}) {
+  const { search = '', category = 'all', suta = 'any', pack = 'any', sort = 'default' } = options;
+  let list = products.slice();
+
+  const q = search.toLowerCase().trim();
+  if (q) {
+    list = list.filter(p =>
+      p.name.toLowerCase().includes(q) ||
+      p.suta.toLowerCase().includes(q) ||
+      p.type.toLowerCase().includes(q) ||
+      p.notes.toLowerCase().includes(q)
+    );
+  }
+
+  if (category !== 'all') {
+    list = list.filter(p => p.type === category);
+  }
+
+  if (suta !== 'any') {
+    list = list.filter(p => p.suta.includes(suta));
+  }
+
+  if (pack !== 'any') {
+    list = list.filter(p => p.packs.includes(pack));
+  }
+
+  if (sort === 'name') {
+    list.sort((a, b) => a.name.localeCompare(b.name));
+  } else if (sort === 'suta') {
+    const n = s => parseInt(s.replace('+', '').split('–')[0], 10);
+    list.sort((a, b) => n(a.suta) - n(b.suta));
+  }
+
+  return list;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { filterProducts };
+}
+if (typeof window !== 'undefined') {
+  window.filterProducts = filterProducts;
+}

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <title>Gravexa Agrow — Premium Makhana</title>
   <meta name="description" content="Gravexa Agrow — Premium foxnuts (Makhana). Explore sizes Suta 3–6 and curated blends for retail and export.">
   <link rel="canonical" href="https://www.gravexaagrow.com/">
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
@@ -14,10 +14,10 @@
 <body>
   <header class="site-header container">
     <a class="brand" href="index.html">
-      <img src="img/logo.png" alt="Gravexa Agrow logo" class="logo">
+      <img src="logo.png" alt="Gravexa Agrow logo" class="logo">
       <div class="brand-text">
         <span class="brand-name">GRAVEXA <strong>AGROW</strong></span>
-        <span class="brand-tagline">Cultivating Future • Premium Makhana</span>
+        <span class="brand-tagline">Cultivating the Future • Premium Makhana</span>
       </div>
     </a>
     <nav class="nav">
@@ -91,7 +91,7 @@
   <footer id="contact" class="site-footer">
     <div class="container footer-grid">
       <div>
-        <img src="img/logo.png" alt="" class="logo sm">
+        <img src="logo.png" alt="" class="logo sm">
         <p>Gravexa Agrow — bringing Bihar’s finest Makhana to the world.</p>
         <p><a href="mailto:sales@gravexaagrow.com">sales@gravexaagrow.com</a> • <a href="tel:+91-00000-00000">+91-00000-00000</a></p>
         <p><a href="https://www.gravexaagrow.com/">www.gravexaagrow.com</a></p>

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "live-server --no-browser --port=5173 .",
     "format": "prettier --write .",
     "lint": "echo 'No lint step for static site'",
-    "build": "echo 'Static site \u2014 nothing to build'"
+    "build": "echo 'Static site \u2014 nothing to build'",
+    "test": "node test/filter.test.js"
   },
   "devDependencies": {
     "live-server": "^1.2.2",

--- a/products.html
+++ b/products.html
@@ -6,7 +6,7 @@
   <title>Makhana Catalog — Gravexa Agrow</title>
   <meta name="description" content="Browse the full Gravexa Agrow Makhana catalog — Suta 3–6 and curated blends 3–5, 5–6, 4–6, and 6+ (Rajanya).">
   <link rel="canonical" href="https://www.gravexaagrow.com/products.html">
-  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="styles.css">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;800&display=swap" rel="stylesheet">
@@ -14,7 +14,7 @@
 <body>
   <header class="site-header container">
     <a class="brand" href="index.html">
-      <img src="img/logo.png" alt="Gravexa Agrow logo" class="logo">
+      <img src="logo.png" alt="Gravexa Agrow logo" class="logo">
       <div class="brand-text">
         <span class="brand-name">GRAVEXA <strong>AGROW</strong></span>
         <span class="brand-tagline">Premium Makhana</span>
@@ -85,6 +85,7 @@
     </div>
   </div>
 
-  <script src="js/app.js"></script>
+  <script src="filter.js"></script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -7,7 +7,7 @@
   "theme_color": "#1A4D2E",
   "icons": [
     {
-      "src": "img/logo.png",
+      "src": "logo.png",
       "sizes": "512x512",
       "type": "image/png"
     }

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { filterProducts } = require('../filter.js');
+
+const PRODUCTS = [
+  { id:'s3', name:'Ankur', suta:'3', type:'single', notes:'Smallest size, everyday cooking & snacks', packs:['200g','500g','1kg','25kg'], price: 'On request' },
+  { id:'s4', name:'Prabha', suta:'4', type:'single', notes:'Balanced size for retail packs', packs:['200g','500g','1kg','25kg'], price: 'On request' },
+  { id:'s5', name:'Shakti', suta:'5', type:'single', notes:'Larger everyday premium', packs:['200g','500g','1kg','25kg'], price: 'On request' },
+  { id:'s6', name:'Divya', suta:'6', type:'single', notes:'Finest large size; luxury & export', packs:['200g','500g','1kg','25kg'], price: 'On request' },
+  { id:'b35', name:'Saumya', suta:'3–5', type:'blend', notes:'Smooth 3–5 mix for value & texture', packs:['500g','1kg','25kg'], price:'On request' },
+  { id:'b56', name:'Ujjwal', suta:'5–6', type:'blend', notes:'High expansion frying, superb crunch', packs:['500g','1kg','25kg'], price:'On request' },
+  { id:'b46', name:'Tejas', suta:'4–6', type:'blend', notes:'Balanced mouthfeel, retail & HoReCa', packs:['500g','1kg','25kg'], price:'On request' },
+  { id:'b6p', name:'Rajanya', suta:'6+', type:'blend', notes:'Elite selection above Suta 6', packs:['500g','1kg','25kg'], price:'On request' },
+];
+
+// Test filter by pack
+t(function filterByPack(){
+  const res = filterProducts(PRODUCTS, { pack: '500g' });
+  assert.ok(res.length > 0, 'no products returned');
+  assert.ok(res.every(p => p.packs.includes('500g')), 'returned product without 500g pack');
+});
+
+// Test sort by suta
+t(function sortBySuta(){
+  const res = filterProducts(PRODUCTS, { sort: 'suta' });
+  const nums = res.map(p => parseInt(p.suta.replace('+','').split('–')[0],10));
+  const sorted = [...nums].sort((a,b)=>a-b);
+  assert.deepStrictEqual(nums, sorted, 'products not sorted by suta');
+});
+
+function t(fn){
+  try {
+    fn();
+    console.log('✓', fn.name);
+  } catch (err) {
+    console.error('✗', fn.name, err.message);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
## Summary
- fix tagline and update logo/stylesheet paths to match repository structure
- document actual asset locations and script path
- add reusable filter helper with tests for pack filtering and suta sorting

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b47485154c832db004a7f5e457cb1c